### PR TITLE
Update docker.rst: fix joligen image name in docker run

### DIFF
--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -21,7 +21,7 @@ To run joliGEN server with docker:
 
 .. code:: bash
 
-   nvidia-docker run -p 8000:8000 docker.jolibrain.com/myjoligen
+   nvidia-docker run -p 8000:8000 docker.jolibrain.com/joligen_server
 			      
 **************
 Docker builds


### PR DESCRIPTION
`docker run` command was using an image named `myjoligen`, fix this name to `joligen_server`